### PR TITLE
fixed breaking bugs, added unit tests, custom hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/PathFindingVisualizer/redux/hooks/useInitializeGrid.js
+++ b/src/PathFindingVisualizer/redux/hooks/useInitializeGrid.js
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { GRID_NODES } from "./visualizeAlgo";
+
+// Custom hook to initialze grid and grid node properties
+// import into 'visualizeAlgo.js' and use if wanted,
+// replace current value for getInitialGrid(),
+// createNode() no longer needed in 'visualizeAlgo' if using this hook
+
+const useInitializeGrid = () => {
+	const [grid, setGrid] = useState(() => {
+		const grid = Array.from(Array(20), () => new Array(51));
+		return grid.map((row, rowIdx) => {
+			return row.map((node, nodeIdx) => createNode(nodeIdx, rowIdx));
+		});
+	});
+
+	const createNode = (col, row) => {
+		return {
+			col,
+			row,
+			isStart:
+				row === GRID_NODES.START_NODE_ROW && col === GRID_NODES.START_NODE_COL,
+			isFinish:
+				row === GRID_NODES.FINISH_NODE_ROW &&
+				col === GRID_NODES.FINISH_NODE_COL,
+			distance: Infinity,
+			isVisited: false,
+			isWall: false,
+			previousNode: null,
+		};
+	};
+
+	return [grid, setGrid];
+};
+
+export default useInitializeGrid;

--- a/src/PathFindingVisualizer/redux/hooks/visualizeAlgo.js
+++ b/src/PathFindingVisualizer/redux/hooks/visualizeAlgo.js
@@ -1,54 +1,95 @@
-import { dijkstra } from "../../../algorithms/dijkstra";
+import {
+	dijkstra,
+	getNodesInShortestPathOrder,
+} from "../../../algorithms/dijkstra";
+
+// global, unchanged variables
+export const GRID_NODES = {
+	START_NODE_ROW: 10,
+	START_NODE_COL: 15,
+	FINISH_NODE_ROW: 10,
+	FINISH_NODE_COL: 35,
+};
+
+// createNode()
+// Creating node objects with the following properties:
+// col, row, isStart, isFinish, distance, isVisited, isWall, previousNode
+// the createNode function is called in the getInitialGrid function
+export const createNode = (col, row) => {
+	return {
+		col,
+		row,
+		isStart:
+			row === GRID_NODES.START_NODE_ROW && col === GRID_NODES.START_NODE_COL,
+		isFinish:
+			row === GRID_NODES.FINISH_NODE_ROW && col === GRID_NODES.FINISH_NODE_COL,
+		distance: Infinity,
+		isVisited: false,
+		isWall: false,
+		previousNode: null,
+	};
+};
+
+// getInitialGrid()
+// Creating grid dimensions in terms of rows and columns
+// nested hash map implementation to optimze runtime
+export const getInitialGrid = () => {
+	// 20 rows, 51 columns
+	const grid = Array.from(Array(20), () => new Array(51));
+	return grid.map((row, rowIdx) => {
+		return row.map((node, nodeIdx) => createNode(nodeIdx, rowIdx));
+	});
+};
+
+// default export
 export default function visualizeAlgo() {
-  const START_NODE_ROW = 10;
-  const START_NODE_COL = 15;
-  const FINISH_NODE_ROW = 10;
-  const FINISH_NODE_COL = 35;
-  function getNewGridWithWallToggled(grid, row, col) {
-    const newGrid = grid.slice();
-    const node = newGrid[row][col];
-    const newNode = { ...node, isWall: !node.isWall };
-    newGrid[row][col] = newNode;
-    return newGrid;
-  }
-  function animateDijkstra(visitedNodesInOrder, nodesInShortestPathOrder) {
-    for (let i = 0; i <= visitedNodesInOrder.length; i++) {
-      if (i === visitedNodesInOrder.length) {
-        setTimeout(() => {
-          animateShortestPath(nodesInShortestPathOrder);
-        }, 10 * i);
-        return;
-      }
-      setTimeout(() => {
-        const node = visitedNodesInOrder[i];
-        document.getElementById(`node-${node.row}-${node.col}`).className =
-          "node node-visited";
-      }, 10 * i);
-    }
-  }
+	function getNewGridWithWallToggled(grid, row, col) {
+		const newGrid = grid.slice();
+		const node = newGrid[row][col];
+		const newNode = { ...node, isWall: !node.isWall };
+		newGrid[row][col] = newNode;
+		return newGrid;
+	}
+	function animateDijkstra(visitedNodesInOrder, nodesInShortestPathOrder) {
+		for (let i = 0; i <= visitedNodesInOrder.length; i++) {
+			if (i === visitedNodesInOrder.length) {
+				setTimeout(() => {
+					animateShortestPath(nodesInShortestPathOrder);
+				}, 10 * i);
+				return;
+			}
+			setTimeout(() => {
+				const node = visitedNodesInOrder[i];
+				document.getElementById(`node-${node.row}-${node.col}`).className =
+					"node node-visited";
+			}, 10 * i);
+		}
+	}
 
-  function animateShortestPath(nodesInShortestPathOrder) {
-    for (let i = 0; i < nodesInShortestPathOrder.length; i++) {
-      setTimeout(() => {
-        const node = nodesInShortestPathOrder[i];
-        document.getElementById(`node-${node.row}-${node.col}`).className =
-          "node node-shortest-path";
-      }, 50 * i);
-    }
-  }
+	function animateShortestPath(nodesInShortestPathOrder) {
+		for (let i = 0; i < nodesInShortestPathOrder.length; i++) {
+			setTimeout(() => {
+				const node = nodesInShortestPathOrder[i];
+				document.getElementById(`node-${node.row}-${node.col}`).className =
+					"node node-shortest-path";
+			}, 50 * i);
+		}
+	}
 
-  function visualizeDjikstra() {
-    const grid = nodes;
-    const startNode = grid[START_NODE_ROW][START_NODE_COL];
-    const finishNode = grid[FINISH_NODE_ROW][FINISH_NODE_COL];
-    const visitedNodesInOrder = dijkstra(grid, startNode, finishNode);
-    const nodesInShortestPathOrder = getNodesInShortestPathOrder(finishNode);
-    animateDijkstra(visitedNodesInOrder, nodesInShortestPathOrder);
-  }
-  return {
-    getNewGridWithWallToggled,
-    animateDijkstra,
-    animateShortestPath,
-    visualizeDjikstra,
-  };
+	function visualizeDjikstra() {
+		const grid = getInitialGrid();
+		const startNode =
+			grid[GRID_NODES.START_NODE_ROW][GRID_NODES.START_NODE_COL];
+		const finishNode =
+			grid[GRID_NODES.FINISH_NODE_ROW][GRID_NODES.FINISH_NODE_COL];
+		const visitedNodesInOrder = dijkstra(grid, startNode, finishNode);
+		const nodesInShortestPathOrder = getNodesInShortestPathOrder(finishNode);
+		animateDijkstra(visitedNodesInOrder, nodesInShortestPathOrder);
+	}
+	return {
+		getNewGridWithWallToggled,
+		animateDijkstra,
+		animateShortestPath,
+		visualizeDjikstra,
+	};
 }

--- a/src/PathFindingVisualizer/redux/hooks/visualizeAlgo.test.js
+++ b/src/PathFindingVisualizer/redux/hooks/visualizeAlgo.test.js
@@ -1,0 +1,64 @@
+// UNIT TESTS USING JEST
+// RUN `npm test` to run tests
+
+import { createNode, getInitialGrid } from "./visualizeAlgo";
+
+// testing createNode function
+describe("createNode", () => {
+	it("should be defined", () => {
+		expect(createNode).toBeDefined();
+	});
+	it("should return an object", () => {
+		expect(typeof createNode()).toBe("object");
+	});
+	it("should return an object with 8 properties", () => {
+		expect(Object.keys(createNode()).length).toBe(8);
+	});
+	it("should set 'col' and 'row' properties from respective arguments", () => {
+		expect(createNode(1, 2).col).toBe(1);
+		expect(createNode(1, 2).row).toBe(2);
+	});
+	it("should be able to take in any positive number for arguments without boundary", () => {
+		expect(createNode(Infinity, 100).col).toBe(Infinity);
+		expect(createNode(100, Infinity).row).toBe(Infinity);
+	});
+	it("should be able to handle negative values for arguments without boundary", () => {
+		expect(createNode(-1, -2).col).toBe(-1);
+		expect(createNode(-1, -2).row).toBe(-2);
+		expect(createNode(-Infinity, -2).col).toBe(-Infinity);
+		expect(createNode(-1, -Infinity).row).toBe(-Infinity);
+	});
+	it("should be able to take in '0' as a col or row value", () => {
+		expect(createNode(0, 0).col).toBe(0);
+		expect(createNode(0, 0).row).toBe(0);
+	});
+	it("should set 'isStart' property to false if row and col do not match start node", () => {
+		expect(createNode(1, 1).isStart).toBe(false);
+	});
+});
+
+// testing getInitialGrid function
+describe("getInitialGrid", () => {
+	it("should be defined", () => {
+		expect(getInitialGrid).toBeDefined();
+	});
+	it("should return an array", () => {
+		expect(Array.isArray(getInitialGrid())).toBe(true);
+	});
+	it("should return an array with 20 subarrays", () => {
+		expect(getInitialGrid().length).toBe(20);
+	});
+	it("should return 51 elements in each subarray", () => {
+		expect(getInitialGrid()[0].length).toBe(51);
+	});
+	it("should render start node at row 10, col 15", () => {
+		const grid = getInitialGrid();
+		const startNode = grid[10][15];
+		expect(getInitialGrid()[10][15]).toEqual(startNode);
+	});
+	it("should render finish node at row 10, col 35", () => {
+		const grid = getInitialGrid();
+		const finishNode = grid[10][35];
+		expect(getInitialGrid()[10][35]).toEqual(finishNode);
+	});
+});


### PR DESCRIPTION
### Description
App was crashing on load due undefined variables in `visualizeAlgo.js`. 
The grid was not being instantiated before use, and grid nodes lacked properties to represent locale, which caused the `getNodesInShortestPathOrder()` function to not work properly.

#### Changes
- Breaking cases fixed, app loads and runs as expected.
- Created `createNode()` function to instantiate properties with each node object.
- Created `getInitialGrid()` function to instantiate grid.
- Implemented and successfully ran unit tests for each new function, tests can be found in `visualizeAlgo.test.js`.
- Created custom hook `useInitializeGrid()` that initializes grid and grid properties, for optional use.
